### PR TITLE
hide telegram link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -86,6 +86,4 @@ googleAnalytics = "UA-137616767-2"
         [[params.services.list]]
                 icon = "fa-telegram"
                 title = "Where do you live."
-                description = "Join us on [Telegram!](https://t.me/joinchat/EeelM03BuW8bejtxl3W4cw)"
-
-
+                description = "Join us on [Telegram!](go-home-stupid-bot/EeelM03BuW8bejtxl3W4cw)"

--- a/themes/hugo-creative-theme/layouts/partials/js.html
+++ b/themes/hugo-creative-theme/layouts/partials/js.html
@@ -8,3 +8,5 @@
 <script src="{{ .Site.BaseURL }}js/wow.min.js"></script>
 {{ "<!-- Custom Theme JavaScript -->" | safeHTML }}
 <script src="{{ .Site.BaseURL }}js/creative.js"></script>
+{{ "<!-- Custom JS -->" | safeHTML }}
+<script src="{{ .Site.BaseURL }}js/custom.js"></script>

--- a/themes/hugo-creative-theme/static/js/custom.js
+++ b/themes/hugo-creative-theme/static/js/custom.js
@@ -1,0 +1,6 @@
+$(document).ready(function () {
+	$('a[href^="go-home-stupid-bot"]').each(function (index) {
+		oh = $(this).attr("href").replace("go-home-stupid-bot", "https://t.me/joinchat");
+		$(this).attr("href", oh);
+	});
+});


### PR DESCRIPTION
Replace link `href` when page is loaded to make link it harder for Telegram bots to find the link.